### PR TITLE
Change DefaultSubnetAccessMode to DefaultAccessModeForPod

### DIFF
--- a/build/yaml/crd/nsx.vmware.com_ippools.yaml
+++ b/build/yaml/crd/nsx.vmware.com_ippools.yaml
@@ -172,10 +172,12 @@ spec:
                   type: object
                 type: array
               type:
-                description: Type defines the type of this IPPool, Public or Private.
+                description: Type defines the type of this IPPool, Public, Private
+                  or Project.
                 enum:
                 - Public
                 - Private
+                - Project
                 type: string
             type: object
           status:

--- a/build/yaml/crd/nsx.vmware.com_subnets.yaml
+++ b/build/yaml/crd/nsx.vmware.com_subnets.yaml
@@ -85,6 +85,7 @@ spec:
                 enum:
                 - Private
                 - Public
+                - Project
                 type: string
               advancedConfig:
                 description: Subnet advanced configuration.

--- a/build/yaml/crd/nsx.vmware.com_subnetsets.yaml
+++ b/build/yaml/crd/nsx.vmware.com_subnetsets.yaml
@@ -85,6 +85,7 @@ spec:
                 enum:
                 - Private
                 - Public
+                - Project
                 type: string
               advancedConfig:
                 description: Subnet advanced configuration.

--- a/build/yaml/crd/nsx.vmware.com_vpcnetworkconfigurations.yaml
+++ b/build/yaml/crd/nsx.vmware.com_vpcnetworkconfigurations.yaml
@@ -61,12 +61,13 @@ spec:
                 description: Default size of Subnet based upon estimated workload
                   count. Defaults to 26.
                 type: integer
-              defaultSubnetAccessMode:
-                description: DefaultSubnetAccessMode defines the access mode of the
-                  default SubnetSet for PodVM and VM. Must be Public or Private.
+              defaultPodSubnetAccessMode:
+                description: DefaultPodSubnetAccessMode defines the access mode of
+                  the default SubnetSet for PodVM. Must be Public or Private.
                 enum:
                 - Public
                 - Private
+                - Project
                 type: string
               edgeClusterPath:
                 description: Edge cluster path on which the networking elements will

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,11 @@ module github.com/vmware-tanzu/nsx-operator
 
 go 1.21
 
+replace (
+	github.com/vmware-tanzu/nsx-operator/pkg/apis => ./pkg/apis
+	github.com/vmware-tanzu/nsx-operator/pkg/client => ./pkg/client
+)
+
 require (
 	github.com/agiledragon/gomonkey/v2 v2.9.0
 	github.com/apparentlymart/go-cidr v1.1.0

--- a/pkg/apis/nsx.vmware.com/v1alpha1/subnet_types.go
+++ b/pkg/apis/nsx.vmware.com/v1alpha1/subnet_types.go
@@ -16,7 +16,7 @@ type SubnetSpec struct {
 	// +kubebuilder:validation:Minimum:=16
 	IPv4SubnetSize int `json:"ipv4SubnetSize,omitempty"`
 	// Access mode of Subnet, accessible only from within VPC or from outside VPC.
-	// +kubebuilder:validation:Enum=Private;Public
+	// +kubebuilder:validation:Enum=Private;Public;Project
 	AccessMode AccessMode `json:"accessMode,omitempty"`
 	// Subnet CIDRS.
 	// +kubebuilder:validation:MinItems=0

--- a/pkg/apis/nsx.vmware.com/v1alpha1/subnetset_types.go
+++ b/pkg/apis/nsx.vmware.com/v1alpha1/subnetset_types.go
@@ -14,7 +14,7 @@ type SubnetSetSpec struct {
 	// +kubebuilder:validation:Minimum:=16
 	IPv4SubnetSize int `json:"ipv4SubnetSize,omitempty"`
 	// Access mode of Subnet, accessible only from within VPC or from outside VPC.
-	// +kubebuilder:validation:Enum=Private;Public
+	// +kubebuilder:validation:Enum=Private;Public;Project
 	AccessMode AccessMode `json:"accessMode,omitempty"`
 	// Subnet advanced configuration.
 	AdvancedConfig AdvancedConfig `json:"advancedConfig,omitempty"`

--- a/pkg/apis/nsx.vmware.com/v1alpha1/vpcnetworkconfiguration_types.go
+++ b/pkg/apis/nsx.vmware.com/v1alpha1/vpcnetworkconfiguration_types.go
@@ -37,10 +37,15 @@ type VPCNetworkConfigurationSpec struct {
 	// Defaults to 26.
 	// +kubebuilder:default=26
 	DefaultIPv4SubnetSize int `json:"defaultIPv4SubnetSize,omitempty"`
-	// DefaultSubnetAccessMode defines the access mode of the default SubnetSet for PodVM and VM.
+	// DefaultPodSubnetAccessMode defines the access mode of the default SubnetSet for PodVM.
 	// Must be Public or Private.
-	// +kubebuilder:validation:Enum=Public;Private
-	DefaultSubnetAccessMode string `json:"defaultSubnetAccessMode,omitempty"`
+	// +kubebuilder:validation:Enum=Public;Private;Project
+	DefaultPodSubnetAccessMode string `json:"defaultPodSubnetAccessMode,omitempty"`
+	// ShortID specifies Identifier to use when displaying VPC context in logs.
+	// Less than equal to 8 characters.
+	// +kubebuilder:validation:MaxLength=8
+	// +optional
+	ShortID string `json:"shortID,omitempty"`
 }
 
 // VPCNetworkConfigurationStatus defines the observed state of VPCNetworkConfiguration

--- a/pkg/apis/nsx.vmware.com/v1alpha2/ippool_types.go
+++ b/pkg/apis/nsx.vmware.com/v1alpha2/ippool_types.go
@@ -36,8 +36,8 @@ type IPPoolList struct {
 
 // IPPoolSpec defines the desired state of IPPool.
 type IPPoolSpec struct {
-	// Type defines the type of this IPPool, Public or Private.
-	// +kubebuilder:validation:Enum=Public;Private
+	// Type defines the type of this IPPool, Public, Private or Project.
+	// +kubebuilder:validation:Enum=Public;Private;Project
 	// +optional
 	Type string `json:"type,omitempty"`
 	// Subnets defines set of subnets need to be allocated.

--- a/pkg/apis/v1alpha1/subnet_types.go
+++ b/pkg/apis/v1alpha1/subnet_types.go
@@ -16,7 +16,7 @@ type SubnetSpec struct {
 	// +kubebuilder:validation:Minimum:=16
 	IPv4SubnetSize int `json:"ipv4SubnetSize,omitempty"`
 	// Access mode of Subnet, accessible only from within VPC or from outside VPC.
-	// +kubebuilder:validation:Enum=Private;Public
+	// +kubebuilder:validation:Enum=Private;Public;Project
 	AccessMode AccessMode `json:"accessMode,omitempty"`
 	// Subnet CIDRS.
 	// +kubebuilder:validation:MinItems=0

--- a/pkg/apis/v1alpha1/subnetset_types.go
+++ b/pkg/apis/v1alpha1/subnetset_types.go
@@ -14,7 +14,7 @@ type SubnetSetSpec struct {
 	// +kubebuilder:validation:Minimum:=16
 	IPv4SubnetSize int `json:"ipv4SubnetSize,omitempty"`
 	// Access mode of Subnet, accessible only from within VPC or from outside VPC.
-	// +kubebuilder:validation:Enum=Private;Public
+	// +kubebuilder:validation:Enum=Private;Public;Project
 	AccessMode AccessMode `json:"accessMode,omitempty"`
 	// Subnet advanced configuration.
 	AdvancedConfig AdvancedConfig `json:"advancedConfig,omitempty"`

--- a/pkg/apis/v1alpha1/vpcnetworkconfiguration_types.go
+++ b/pkg/apis/v1alpha1/vpcnetworkconfiguration_types.go
@@ -37,10 +37,10 @@ type VPCNetworkConfigurationSpec struct {
 	// Defaults to 26.
 	// +kubebuilder:default=26
 	DefaultIPv4SubnetSize int `json:"defaultIPv4SubnetSize,omitempty"`
-	// DefaultSubnetAccessMode defines the access mode of the default SubnetSet for PodVM and VM.
+	// DefaultPodSubnetAccessMode defines the access mode of the default SubnetSet for PodVM.
 	// Must be Public or Private.
-	// +kubebuilder:validation:Enum=Public;Private
-	DefaultSubnetAccessMode string `json:"defaultSubnetAccessMode,omitempty"`
+	// +kubebuilder:validation:Enum=Public;Private;Project
+	DefaultPodSubnetAccessMode string `json:"defaultPodSubnetAccessMode,omitempty"`
 	// ShortID specifies Identifier to use when displaying VPC context in logs.
 	// Less than equal to 8 characters.
 	// +kubebuilder:validation:MaxLength=8

--- a/pkg/apis/v1alpha2/ippool_types.go
+++ b/pkg/apis/v1alpha2/ippool_types.go
@@ -36,8 +36,8 @@ type IPPoolList struct {
 
 // IPPoolSpec defines the desired state of IPPool.
 type IPPoolSpec struct {
-	// Type defines the type of this IPPool, Public or Private.
-	// +kubebuilder:validation:Enum=Public;Private
+	// Type defines the type of this IPPool, Public, Private or Project.
+	// +kubebuilder:validation:Enum=Public;Private;Project
 	// +optional
 	Type string `json:"type,omitempty"`
 	// Subnets defines set of subnets need to be allocated.

--- a/pkg/controllers/ippool/ippool_controller.go
+++ b/pkg/controllers/ippool/ippool_controller.go
@@ -141,7 +141,7 @@ func (r *IPPoolReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			updateFail(r, &ctx, obj, &err)
 			return resultRequeue, err
 		}
-		obj.Spec.Type = vpcNetworkConfig.DefaultSubnetAccessMode
+		obj.Spec.Type = "Private"
 	}
 
 	if obj.ObjectMeta.DeletionTimestamp.IsZero() {

--- a/pkg/controllers/pod/pod_controller.go
+++ b/pkg/controllers/pod/pod_controller.go
@@ -92,7 +92,11 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 			return common.ResultRequeue, err
 		}
 		contextID := *node.Id
-		nsxSubnetPortState, err := r.SubnetPortService.CreateOrUpdateSubnetPort(pod, nsxSubnetPath, contextID, &pod.ObjectMeta.Labels)
+		nsxSubnet, err := r.SubnetService.GetSubnetByPath(nsxSubnetPath)
+		if err != nil {
+			return common.ResultRequeue, err
+		}
+		nsxSubnetPortState, err := r.SubnetPortService.CreateOrUpdateSubnetPort(pod, nsxSubnet, contextID, &pod.ObjectMeta.Labels)
 		if err != nil {
 			log.Error(err, "failed to create or update NSX subnet port, would retry exponentially", "pod.Name", req.NamespacedName, "pod.UID", pod.UID)
 			updateFail(r, &ctx, pod, &err)

--- a/pkg/controllers/subnet/subnet_controller.go
+++ b/pkg/controllers/subnet/subnet_controller.go
@@ -80,7 +80,7 @@ func (r *SubnetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 				return ResultRequeue, err
 			}
 			if obj.Spec.AccessMode == "" {
-				obj.Spec.AccessMode = v1alpha1.AccessMode(vpcNetworkConfig.DefaultSubnetAccessMode)
+				obj.Spec.AccessMode = v1alpha1.AccessMode("Private")
 			}
 			if obj.Spec.IPv4SubnetSize == 0 {
 				obj.Spec.IPv4SubnetSize = vpcNetworkConfig.DefaultIPv4SubnetSize

--- a/pkg/controllers/subnetset/subnetset_controller.go
+++ b/pkg/controllers/subnetset/subnetset_controller.go
@@ -71,7 +71,7 @@ func (r *SubnetSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 					return ResultRequeue, err
 				}
 				if obj.Spec.AccessMode == "" {
-					obj.Spec.AccessMode = v1alpha1.AccessMode(vpcNetworkConfig.DefaultSubnetAccessMode)
+					obj.Spec.AccessMode = v1alpha1.AccessMode("Private")
 				}
 				if obj.Spec.IPv4SubnetSize == 0 {
 					obj.Spec.IPv4SubnetSize = vpcNetworkConfig.DefaultIPv4SubnetSize

--- a/pkg/controllers/vpc/vpc_utils.go
+++ b/pkg/controllers/vpc/vpc_utils.go
@@ -153,17 +153,17 @@ func buildNetworkConfigInfo(vpcConfigCR v1alpha1.VPCNetworkConfiguration) (*type
 	}
 
 	ninfo := &types.VPCNetworkConfigInfo{
-		IsDefault:               isDefaultNetworkConfigCR(vpcConfigCR),
-		Org:                     org,
-		Name:                    vpcConfigCR.Name,
-		DefaultGatewayPath:      vpcConfigCR.Spec.DefaultGatewayPath,
-		EdgeClusterPath:         vpcConfigCR.Spec.EdgeClusterPath,
-		NsxtProject:             project,
-		ExternalIPv4Blocks:      vpcConfigCR.Spec.ExternalIPv4Blocks,
-		PrivateIPv4CIDRs:        vpcConfigCR.Spec.PrivateIPv4CIDRs,
-		DefaultIPv4SubnetSize:   vpcConfigCR.Spec.DefaultIPv4SubnetSize,
-		DefaultSubnetAccessMode: vpcConfigCR.Spec.DefaultSubnetAccessMode,
-		ShortID:                 vpcConfigCR.Spec.ShortID,
+		IsDefault:                  isDefaultNetworkConfigCR(vpcConfigCR),
+		Org:                        org,
+		Name:                       vpcConfigCR.Name,
+		DefaultGatewayPath:         vpcConfigCR.Spec.DefaultGatewayPath,
+		EdgeClusterPath:            vpcConfigCR.Spec.EdgeClusterPath,
+		NsxtProject:                project,
+		ExternalIPv4Blocks:         vpcConfigCR.Spec.ExternalIPv4Blocks,
+		PrivateIPv4CIDRs:           vpcConfigCR.Spec.PrivateIPv4CIDRs,
+		DefaultIPv4SubnetSize:      vpcConfigCR.Spec.DefaultIPv4SubnetSize,
+		DefaultPodSubnetAccessMode: vpcConfigCR.Spec.DefaultPodSubnetAccessMode,
+		ShortID:                    vpcConfigCR.Spec.ShortID,
 	}
 	return ninfo, nil
 }

--- a/pkg/controllers/vpc/vpc_utils_test.go
+++ b/pkg/controllers/vpc/vpc_utils_test.go
@@ -74,22 +74,22 @@ func TestBuildNetworkConfigInfo(t *testing.T) {
 	assert.NotNil(t, e)
 
 	spec1 := v1alpha1.VPCNetworkConfigurationSpec{
-		DefaultGatewayPath:      "test-gw-path-1",
-		EdgeClusterPath:         "test-edge-path-1",
-		ExternalIPv4Blocks:      []string{"external-ipb-1", "external-ipb-2"},
-		PrivateIPv4CIDRs:        []string{"private-ipb-1", "private-ipb-2"},
-		DefaultIPv4SubnetSize:   64,
-		DefaultSubnetAccessMode: "Public",
-		NSXTProject:             "/orgs/default/projects/nsx_operator_e2e_test",
+		DefaultGatewayPath:         "test-gw-path-1",
+		EdgeClusterPath:            "test-edge-path-1",
+		ExternalIPv4Blocks:         []string{"external-ipb-1", "external-ipb-2"},
+		PrivateIPv4CIDRs:           []string{"private-ipb-1", "private-ipb-2"},
+		DefaultIPv4SubnetSize:      64,
+		DefaultPodSubnetAccessMode: "Public",
+		NSXTProject:                "/orgs/default/projects/nsx_operator_e2e_test",
 	}
 	spec2 := v1alpha1.VPCNetworkConfigurationSpec{
-		DefaultGatewayPath:      "test-gw-path-2",
-		EdgeClusterPath:         "test-edge-path-2",
-		ExternalIPv4Blocks:      []string{"external-ipb-1", "external-ipb-2"},
-		PrivateIPv4CIDRs:        []string{"private-ipb-1", "private-ipb-2"},
-		DefaultIPv4SubnetSize:   32,
-		DefaultSubnetAccessMode: "Private",
-		NSXTProject:             "/orgs/anotherOrg/projects/anotherProject",
+		DefaultGatewayPath:         "test-gw-path-2",
+		EdgeClusterPath:            "test-edge-path-2",
+		ExternalIPv4Blocks:         []string{"external-ipb-1", "external-ipb-2"},
+		PrivateIPv4CIDRs:           []string{"private-ipb-1", "private-ipb-2"},
+		DefaultIPv4SubnetSize:      32,
+		DefaultPodSubnetAccessMode: "Private",
+		NSXTProject:                "/orgs/anotherOrg/projects/anotherProject",
 	}
 	testCRD1 := v1alpha1.VPCNetworkConfiguration{
 		Spec: spec1,
@@ -134,7 +134,7 @@ func TestBuildNetworkConfigInfo(t *testing.T) {
 			assert.Equal(t, tt.org, nc.Org)
 			assert.Equal(t, tt.project, nc.NsxtProject)
 			assert.Equal(t, tt.subnetSize, nc.DefaultIPv4SubnetSize)
-			assert.Equal(t, tt.accessMode, nc.DefaultSubnetAccessMode)
+			assert.Equal(t, tt.accessMode, nc.DefaultPodSubnetAccessMode)
 			assert.Equal(t, tt.isDefault, nc.IsDefault)
 		})
 	}

--- a/pkg/nsx/services/common/services.go
+++ b/pkg/nsx/services/common/services.go
@@ -20,7 +20,8 @@ type VPCServiceProvider interface {
 }
 
 type SubnetServiceProvider interface {
-	GetSubnetByKey(key string) *model.VpcSubnet
+	GetSubnetByKey(key string) (*model.VpcSubnet, error)
+	GetSubnetByPath(path string) (*model.VpcSubnet, error)
 	GetSubnetsByIndex(key, value string) []*model.VpcSubnet
 	CreateOrUpdateSubnet(obj client.Object, vpcInfo VPCResourceInfo, tags []model.Tag) (string, error)
 	GenerateSubnetNSTags(obj client.Object, nsUID string) []model.Tag

--- a/pkg/nsx/services/common/types.go
+++ b/pkg/nsx/services/common/types.go
@@ -197,15 +197,15 @@ type VPCResourceInfo struct {
 }
 
 type VPCNetworkConfigInfo struct {
-	IsDefault               bool
-	Org                     string
-	Name                    string
-	DefaultGatewayPath      string
-	EdgeClusterPath         string
-	NsxtProject             string
-	ExternalIPv4Blocks      []string
-	PrivateIPv4CIDRs        []string
-	DefaultIPv4SubnetSize   int
-	DefaultSubnetAccessMode string
-	ShortID                 string
+	IsDefault                  bool
+	Org                        string
+	Name                       string
+	DefaultGatewayPath         string
+	EdgeClusterPath            string
+	NsxtProject                string
+	ExternalIPv4Blocks         []string
+	PrivateIPv4CIDRs           []string
+	DefaultIPv4SubnetSize      int
+	DefaultPodSubnetAccessMode string
+	ShortID                    string
 }

--- a/pkg/nsx/services/subnet/subnet.go
+++ b/pkg/nsx/services/subnet/subnet.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -275,8 +276,22 @@ func (service *SubnetService) UpdateSubnetSetStatus(obj *v1alpha1.SubnetSet) err
 	return nil
 }
 
-func (service *SubnetService) GetSubnetByKey(key string) *model.VpcSubnet {
-	return service.SubnetStore.GetByKey(key)
+func (service *SubnetService) GetSubnetByKey(key string) (*model.VpcSubnet, error) {
+	nsxSubnet := service.SubnetStore.GetByKey(key)
+	if nsxSubnet == nil {
+		return nil, errors.New("NSX subnet not found in store")
+	}
+	return nsxSubnet, nil
+}
+
+func (service *SubnetService) GetSubnetByPath(path string) (*model.VpcSubnet, error) {
+	pathSlice := strings.Split(path, "/")
+	if len(pathSlice) == 0 {
+		return nil, fmt.Errorf("invalid path '%s' while getting subnet", path)
+	}
+	key := pathSlice[len(pathSlice)-1]
+	nsxSubnet, err := service.GetSubnetByKey(key)
+	return nsxSubnet, err
 }
 
 func (service *SubnetService) ListSubnetID() sets.Set[string] {

--- a/pkg/nsx/services/subnetport/builder_test.go
+++ b/pkg/nsx/services/subnetport/builder_test.go
@@ -1,0 +1,122 @@
+package subnetport
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware/vsphere-automation-sdk-go/services/nsxt/model"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/vmware-tanzu/nsx-operator/pkg/apis/v1alpha1"
+	"github.com/vmware-tanzu/nsx-operator/pkg/config"
+	mock_client "github.com/vmware-tanzu/nsx-operator/pkg/mock/controller-runtime/client"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx"
+	"github.com/vmware-tanzu/nsx-operator/pkg/nsx/services/common"
+)
+
+func TestBuildSubnetPort(t *testing.T) {
+	mockCtl := gomock.NewController(t)
+	k8sClient := mock_client.NewMockClient(mockCtl)
+	service := &SubnetPortService{
+		Service: common.Service{
+			Client:    k8sClient,
+			NSXClient: &nsx.Client{},
+			NSXConfig: &config.NSXOperatorConfig{
+				NsxConfig: &config.NsxConfig{
+					EnforcementPoint: "vmc-enforcementpoint",
+				},
+				CoeConfig: &config.CoeConfig{
+					Cluster: "fake_cluster",
+				},
+			},
+		},
+	}
+	ctx := context.Background()
+	namespace := &corev1.Namespace{}
+	k8sClient.EXPECT().Get(ctx, gomock.Any(), namespace).Return(nil).Do(
+		func(_ context.Context, _ client.ObjectKey, obj client.Object, option ...client.GetOption) error {
+			return nil
+		})
+
+	tests := []struct {
+		name          string
+		obj           interface{}
+		nsxSubnet     *model.VpcSubnet
+		contextID     string
+		labelTags     *map[string]string
+		expectedPort  *model.VpcSubnetPort
+		expectedError error
+	}{
+		{
+			name: "01",
+			obj: &v1alpha1.SubnetPort{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1alpha1",
+					Kind:       "SubnetPort",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					UID:       "2ccec3b9-7546-4fd2-812a-1e3a4afd7acc",
+					Name:      "fake_subnetport",
+					Namespace: "fake_ns",
+				},
+			},
+			nsxSubnet: &model.VpcSubnet{
+				DhcpConfig: &model.VpcSubnetDhcpConfig{
+					EnableDhcp: common.Bool(true),
+				},
+				Path: common.String("fake_path"),
+			},
+			contextID: "fake_context_id",
+			labelTags: nil,
+			expectedPort: &model.VpcSubnetPort{
+				DisplayName: common.String("port-fake_subnetport"),
+				Id:          common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
+				Tags: []model.Tag{
+					{
+						Scope: common.String("nsx-op/cluster"),
+						Tag:   common.String("fake_cluster"),
+					},
+					{
+						Scope: common.String("nsx-op/version"),
+						Tag:   common.String("1.0.0"),
+					},
+					{
+						Scope: common.String("nsx-op/vm_namespace"),
+						Tag:   common.String("fake_ns"),
+					},
+					{
+						Scope: common.String("nsx-op/subnetport_name"),
+						Tag:   common.String("fake_subnetport"),
+					},
+					{
+						Scope: common.String("nsx-op/subnetport_uid"),
+						Tag:   common.String("2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
+					},
+				},
+				Path:       common.String("fake_path/ports/2ccec3b9-7546-4fd2-812a-1e3a4afd7acc"),
+				ParentPath: common.String("fake_path"),
+				Attachment: &model.PortAttachment{
+					AllocateAddresses: common.String("DHCP"),
+					Type_:             common.String("STATIC"),
+					Id:                common.String("32636365-6333-4239-ad37-3534362d3466"),
+					TrafficTag:        common.Int64(0),
+				},
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			observedPort, err := service.buildSubnetPort(tt.obj, tt.nsxSubnet, tt.contextID, tt.labelTags)
+			assert.Equal(t, tt.expectedPort, observedPort)
+			assert.Equal(t, common.CompareResource(SubnetPortToComparable(tt.expectedPort), SubnetPortToComparable(observedPort)), false)
+			assert.Equal(t, tt.expectedError, err)
+		})
+	}
+
+}

--- a/test/e2e/manifest/testSubnet/subnetport-in-dhcp-subnetset.yaml
+++ b/test/e2e/manifest/testSubnet/subnetport-in-dhcp-subnetset.yaml
@@ -1,0 +1,7 @@
+apiVersion: nsx.vmware.com/v1alpha1
+kind: SubnetPort
+metadata:
+  name: port-in-dhcp-subnetset
+  namespace: subnet-e2e
+spec:
+  subnetSet: user-pod-subnetset-dhcp

--- a/test/e2e/manifest/testSubnet/subnetport-in-static-subnetset.yaml
+++ b/test/e2e/manifest/testSubnet/subnetport-in-static-subnetset.yaml
@@ -1,7 +1,7 @@
 apiVersion: nsx.vmware.com/v1alpha1
 kind: SubnetPort
 metadata:
-  name: port-2
+  name: port-in-static-subnetset
   namespace: subnet-e2e
 spec:
-  subnetSet: user-pod-subnetset
+  subnetSet: user-pod-subnetset-static

--- a/test/e2e/manifest/testSubnet/subnetset-dhcp.yaml
+++ b/test/e2e/manifest/testSubnet/subnetset-dhcp.yaml
@@ -1,9 +1,8 @@
 apiVersion: nsx.vmware.com/v1alpha1
 kind: SubnetSet
 metadata:
-  name: user-pod-subnetset
+  name: user-pod-subnetset-dhcp
   namespace: subnet-e2e
 spec:
-  advancedConfig:
-    staticIPAllocation:
-      enable: true
+  DHCPConfig:
+    enableDHCP: true

--- a/test/e2e/manifest/testSubnet/subnetset-static.yaml
+++ b/test/e2e/manifest/testSubnet/subnetset-static.yaml
@@ -1,0 +1,9 @@
+apiVersion: nsx.vmware.com/v1alpha1
+kind: SubnetSet
+metadata:
+  name: user-pod-subnetset-static
+  namespace: subnet-e2e
+spec:
+  advancedConfig:
+    staticIPAllocation:
+      enable: true

--- a/test/e2e/nsx_subnet_test.go
+++ b/test/e2e/nsx_subnet_test.go
@@ -29,7 +29,7 @@ const (
 	SubnetDeletionTimeout = 300 * time.Second
 )
 
-func verifySubnetSetCR(subnetSet string) bool {
+func verifySubnetSetCR(subnetSet string, subnetType string) bool {
 	vpcNetworkConfig, err := testData.crdClientset.NsxV1alpha1().VPCNetworkConfigurations().Get(context.TODO(), VPCNetworkConfigCRName, v1.GetOptions{})
 	if err != nil {
 		log.Printf("Failed to get VPCNetworkConfiguration %s: %v", VPCNetworkConfigCRName, err)
@@ -40,8 +40,14 @@ func verifySubnetSetCR(subnetSet string) bool {
 		log.Printf("Failed to get %s/%s: %s", E2ENamespace, subnetSet, err)
 		return false
 	}
-	if string(subnetSetCR.Spec.AccessMode) != vpcNetworkConfig.Spec.DefaultSubnetAccessMode {
-		log.Printf("AccessMode is %s, while it's expected to be %s", subnetSetCR.Spec.AccessMode, vpcNetworkConfig.Spec.DefaultSubnetAccessMode)
+	var desiredSubnetType string
+	if subnetType == "" {
+		desiredSubnetType = vpcNetworkConfig.Spec.DefaultPodSubnetAccessMode
+	} else {
+		desiredSubnetType = subnetType
+	}
+	if string(subnetSetCR.Spec.AccessMode) != desiredSubnetType {
+		log.Printf("AccessMode is %s, while it's expected to be %s", subnetSetCR.Spec.AccessMode, desiredSubnetType)
 		return false
 	}
 	if subnetSetCR.Spec.IPv4SubnetSize != vpcNetworkConfig.Spec.DefaultIPv4SubnetSize {
@@ -77,8 +83,8 @@ func defaultSubnetSet(t *testing.T) {
 	assertNil(t, err)
 
 	// 2. Check `Ipv4SubnetSize` and `AccessMode` should be same with related fields in VPCNetworkConfig.
-	assertTrue(t, verifySubnetSetCR(common.DefaultVMSubnetSet))
-	assertTrue(t, verifySubnetSetCR(common.DefaultPodSubnetSet))
+	assertTrue(t, verifySubnetSetCR(common.DefaultVMSubnetSet, "Private"))
+	assertTrue(t, verifySubnetSetCR(common.DefaultPodSubnetSet, ""))
 
 	portPath, _ := filepath.Abs("./manifest/testSubnet/subnetport_1.yaml")
 	err = applyYAML(portPath, E2ENamespace)
@@ -180,7 +186,7 @@ func UserSubnetSet(t *testing.T) {
 		assertNil(t, err)
 
 		// 2. Check `Ipv4SubnetSize` and `AccessMode` should be same with related fields in VPCNetworkConfig.
-		assertTrue(t, verifySubnetSetCR(subnetSetName))
+		assertTrue(t, verifySubnetSetCR(subnetSetName, "Private"))
 
 		portPath, _ := filepath.Abs(portYAML)
 		err = applyYAML(portPath, E2ENamespace)
@@ -210,8 +216,8 @@ func sharedSubnetSet(t *testing.T) {
 	assertNil(t, err)
 
 	// 2. Check `Ipv4SubnetSize` and `AccessMode` should be same with related fields in VPCNetworkConfig.
-	assertTrue(t, verifySubnetSetCR(common.DefaultVMSubnetSet))
-	assertTrue(t, verifySubnetSetCR(common.DefaultPodSubnetSet))
+	assertTrue(t, verifySubnetSetCR(common.DefaultVMSubnetSet, "Private"))
+	assertTrue(t, verifySubnetSetCR(common.DefaultPodSubnetSet, ""))
 
 	portPath, _ := filepath.Abs("./manifest/testSubnet/subnetport_3.yaml")
 	err = applyYAML(portPath, E2ENamespaceShared)


### PR DESCRIPTION
As we discussed, we want to set default Pod Subnet type in Namespace settings, and always keep VMs default to "Private" Subnets.
Also, besides "Public" and "Private" access mode, also add "Project" and "Isolated" for user to choose.